### PR TITLE
Feature: add WriteOpts for package.json

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -164,3 +164,35 @@ fn test_write_json() {
     .expect("read file failed!");
   assert_eq!(content, r#"{"name":"test"}"#);
 }
+
+#[test]
+fn test_write_json_with_opts() {
+  use serde::Serialize;
+  use std::env::current_dir;
+  use tempfile::tempdir_in;
+
+  let dir = tempdir_in(current_dir().unwrap()).expect("create temp_dir failed!");
+  let file_path = dir.path().join("test.json");
+  #[derive(Serialize, Debug)]
+  struct TestJson {
+    name: String,
+  }
+
+  let test_json = TestJson {
+    name: "test".to_string(),
+  };
+
+  write_json(&file_path, test_json, Some(WriteOpts { pretty: true })).expect("write json failed");
+  assert!(file_path.exists());
+  let mut file = File::open(&file_path).expect("open file failed!");
+  let mut content = String::new();
+  file
+    .read_to_string(&mut content)
+    .expect("read file failed!");
+  assert_eq!(
+    content,
+    r#"{
+  "name": "test"
+}"#
+  );
+}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use crate::write::WriteOpt;
+use crate::write::WriteOpts;
 
 pub fn find_closest_file<P: AsRef<Path>>(filename: &str, current_dir: P) -> Result<PathBuf> {
   let mut current_dir = PathBuf::from(current_dir.as_ref());
@@ -41,7 +41,7 @@ where
 pub fn write_json<Json, FilePath>(
   file_path: FilePath,
   json: Json,
-  opts: Option<WriteOpt>,
+  opts: Option<WriteOpts>,
 ) -> Result<()>
 where
   Json: serde::Serialize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,5 +66,9 @@ mod fs;
 mod manager;
 mod schema;
 
+mod opts;
+
 pub use crate::manager::{PackageJsonManager, PACKAGE_JSON_FILENAME};
 pub use crate::schema::*;
+
+pub use opts::*;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,5 +1,5 @@
 use crate::fs;
-use crate::write::WriteOpt;
+use crate::write::WriteOpts;
 use crate::PackageJson;
 use anyhow::{format_err, Result};
 use std::env;
@@ -148,7 +148,7 @@ impl PackageJsonManager {
   ///   manager.write().expect("Couldn't write package.json");
   /// }
   /// ```
-  pub fn write_with_opts(&mut self, opts: WriteOpt) -> Result<()> {
+  pub fn write_with_opts(&mut self, opts: WriteOpts) -> Result<()> {
     self
       .file_path
       .as_ref()
@@ -196,7 +196,7 @@ impl PackageJsonManager {
   ///     .expect("Couldn't write package.json");
   /// }
   /// ```
-  pub fn write_to_with_opts(&mut self, file_path: &Path, opts: WriteOpt) -> Result<()> {
+  pub fn write_to_with_opts(&mut self, file_path: &Path, opts: WriteOpts) -> Result<()> {
     fs::write_json(file_path, &self.json, Some(opts))
   }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,4 +1,5 @@
 use crate::fs;
+use crate::write::WriteOpt;
 use crate::PackageJson;
 use anyhow::{format_err, Result};
 use std::env;
@@ -125,7 +126,33 @@ impl PackageJsonManager {
     self
       .file_path
       .as_ref()
-      .map(|file_path| fs::write_json(file_path, &self.json))
+      .map(|file_path| fs::write_json(file_path, &self.json, None))
+      .unwrap_or_else(|| {
+        Err(format_err!(
+          "Couldn't find an available {} file.",
+          PACKAGE_JSON_FILENAME
+        ))
+      })
+  }
+
+  /// Use the current `package.json` content to write the target `package.json` file,
+  /// with write options.
+  /// ```
+  /// use package_json::PackageJsonManager;
+  /// let mut manager = PackageJsonManager::new();
+  /// if manager.locate_closest().is_ok() {
+  ///   if let Ok(mut json) = manager.read_mut() {
+  ///     json.name = "new name".to_string();
+  ///     json.version = "1.0.0".to_string();
+  ///   }
+  ///   manager.write().expect("Couldn't write package.json");
+  /// }
+  /// ```
+  pub fn write_with_opts(&mut self, opts: WriteOpt) -> Result<()> {
+    self
+      .file_path
+      .as_ref()
+      .map(|file_path| fs::write_json(file_path, &self.json, Some(opts)))
       .unwrap_or_else(|| {
         Err(format_err!(
           "Couldn't find an available {} file.",
@@ -150,7 +177,27 @@ impl PackageJsonManager {
   /// }
   /// ```
   pub fn write_to(&mut self, file_path: &Path) -> Result<()> {
-    fs::write_json(file_path, &self.json)
+    fs::write_json(file_path, &self.json, None)
+  }
+
+  /// Write the current `package.json` content to the specific `package.json` file,
+  /// with write options.
+  /// ```
+  /// use package_json::PackageJsonManager;
+  /// use std::path::Path;
+  /// let mut manager = PackageJsonManager::new();
+  /// if manager.locate_closest().is_ok() {
+  ///   if let Ok(mut json) = manager.read_mut() {
+  ///     json.name = "new name".to_string();
+  ///     json.version = "1.0.0".to_string();
+  ///   }
+  ///   manager
+  ///     .write_to(&Path::new("/path/to/package.json"))
+  ///     .expect("Couldn't write package.json");
+  /// }
+  /// ```
+  pub fn write_to_with_opts(&mut self, file_path: &Path, opts: WriteOpt) -> Result<()> {
+    fs::write_json(file_path, &self.json, Some(opts))
   }
 }
 

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -1,0 +1,1 @@
+pub mod write;

--- a/src/opts/write.rs
+++ b/src/opts/write.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, Default)]
+pub struct WriteOpt {
+  pub pretty: bool,
+}

--- a/src/opts/write.rs
+++ b/src/opts/write.rs
@@ -1,4 +1,4 @@
 #[derive(Debug, Default)]
-pub struct WriteOpt {
+pub struct WriteOpts {
   pub pretty: bool,
 }


### PR DESCRIPTION
This closes #2 

This PR adds two new methods for package.json write:
- `write_with_opts`;
- `write_to_with_opts`;

The `fs::write_json` gets updated with an `Option<WriteOpts>`. The `WriteOpts` implements `Default`, which is used if `None`.

I've added as separate method in order to prevent major API change. If desired by the maintainer, `write` / `write_to` could be updated to contain  `opts`  argument.