### PR TITLE
improve handling of a variety of schema changes including enum's, config boolean and nested values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 serde = { version = "1.0.138", features = ["derive"] }
 anyhow = "1.0.58"
 serde_json = "1.0.82"
-derive_builder = "0.12.0"
+derive_builder = "0.20.2"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ all-features = true
 [dependencies]
 serde = { version = "1.0.138", features = ["derive"] }
 anyhow = "1.0.58"
-serde_json = "1.0.82"
+serde_json = "1.0.138"
 derive_builder = "0.20.2"
 
 [features]
 default = []
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile = "3.16.0"

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -324,7 +324,7 @@ fn test_writable() {
       "{}",
       format!("create file writer failed: {:?}", file_writer)
     );
-    if let Ok(mut json) = file_writer {
+    if let Ok(json) = file_writer {
       json.name = "test2".to_string();
       json.version = "0.0.2".to_string();
       assert!(manager.write().is_ok());
@@ -336,7 +336,7 @@ fn test_writable() {
 
   // case `as_mut`
   {
-    let mut mutable_handler = manager.as_mut();
+    let mutable_handler = manager.as_mut();
     mutable_handler.name = "test3".to_string();
     mutable_handler.version = "0.0.3".to_string();
     let file_reader = manager.as_ref();

--- a/src/schema/ignore.rs
+++ b/src/schema/ignore.rs
@@ -2,5 +2,7 @@ use std::collections::HashMap;
 
 pub fn ignore_scripts(data: &HashMap<String, String>) -> bool {
   let default_value = super::default::scripts();
-  data.keys().all(|item| default_value.get(item) == data.get(item))
+  data
+    .keys()
+    .all(|item| default_value.get(item) == data.get(item))
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -364,7 +364,7 @@ fn test_repository_record_with_directory() {
 }
 
 #[test]
-fn test_author_serialization() {
+fn test_author_string_serialization() {
   let json = r#"
  {
 	"name": "package-name",
@@ -377,5 +377,49 @@ fn test_author_serialization() {
 		"packages/*"
 	]
 }"#;
-  let _package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  let package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  let expected = String::from("A string value");
+  match package_json.author.unwrap() {
+    PackagePeople::Record(_) => {
+      panic!("expected a auhor string, got a struct");
+    }
+    PackagePeople::Literal(literal) => {
+      assert_eq!(literal, expected, "expected {} got {}", expected, literal);
+    }
+  }
+}
+
+#[test]
+fn test_author_object_serialization() {
+  let json = r#"
+ {
+	"name": "package-name",
+	"private": true,
+	"version": "1.0.0",
+	"description": "Something for everyone",
+	"author": {
+    "name": "Barney Rubble",
+    "email": "b@rubble.com",
+    "url": "http://barnyrubble.tumblr.com/"
+  },
+	"license": "Apache-2.0",
+	"workspaces": [
+		"packages/*"
+	]
+}"#;
+  let package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  let expected = String::from("http://barnyrubble.tumblr.com/");
+  match package_json.author.unwrap() {
+    PackagePeople::Record(record) => {
+      let author_url = record.url.unwrap();
+      assert_eq!(
+        author_url, expected,
+        "expected author url: {} got: {}",
+        expected, author_url
+      );
+    }
+    PackagePeople::Literal(_) => {
+      panic!("expected a auhor struct, got a string")
+    }
+  }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -148,6 +148,7 @@ pub struct PackageJson {
 
 /// see [PackageJson::bugs](PackageJson::bugs)
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
 pub enum PackageBugs {
   Url(String),
   Record(PackageBugsRecord),
@@ -161,6 +162,7 @@ pub struct PackageBugsRecord {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
 pub enum PackagePeople {
   Literal(String),
   Record(PackagePeopleRecord),
@@ -175,6 +177,7 @@ pub struct PackagePeopleRecord {
 
 /// see [PackageJson::funding](PackageJson::funding)
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
 pub enum PackageFunding {
   Url(String),
   Record(PackageFundingRecord),
@@ -190,6 +193,7 @@ pub struct PackageFundingRecord {
 
 /// see [PackageJson::bin](PackageJson::bin)
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
 pub enum PackageBin {
   Literal(String),
   Record(HashMap<String, String>),
@@ -197,6 +201,7 @@ pub enum PackageBin {
 
 /// see [PackageJson::man](PackageJson::man)
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
 pub enum PackageMan {
   Literal(String),
   Slice(Vec<String>),
@@ -356,4 +361,21 @@ fn test_repository_record_with_directory() {
       panic!("expected a repository struct, got a url")
     }
   }
+}
+
+#[test]
+fn test_author_serialization() {
+  let json = r#"
+ {
+	"name": "package-name",
+	"private": true,
+	"version": "1.0.0",
+	"description": "Something for everyone",
+	"author": "A string value",
+	"license": "Apache-2.0",
+	"workspaces": [
+		"packages/*"
+	]
+}"#;
+  let _package_json = serde_json::from_str::<PackageJson>(json).unwrap();
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -157,8 +157,8 @@ pub enum PackageBugs {
 /// see [PackageJson::bugs](PackageJson::bugs)
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct PackageBugsRecord {
-  pub url: String,
-  pub email: String,
+  pub url: Option<String>,
+  pub email: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -485,6 +485,36 @@ fn test_config_with_nested_serialization() {
       .unwrap(),
     &expected
   );
+}
+
+#[test]
+fn test_bugs_with_nested_serialization() {
+  let json = r#"
+   {
+    "name": "package-name",
+    "private": true,
+    "version": "1.0.0",
+    "description": "Something for everyone",
+    "author": {
+      "name": "Barney Rubble",
+      "email": "b@rubble.com",
+      "url": "http://barnyrubble.tumblr.com/"
+    },
+    "bugs": {
+      "url": "https://github.com/jquery/esprima/issues"
+    }
+  }"#;
+  let package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  let expected: String = String::from("https://github.com/jquery/esprima/issues");
+  match package_json.bugs.unwrap() {
+    PackageBugs::Url(_url) => {
+      panic!("expected a repository url, got a struct")
+    }
+    PackageBugs::Record(record) => {
+      let url = record.url.unwrap();
+      assert_eq!(url, expected, "expected {} got {}", expected, url);
+    }
+  }
 }
 
 #[test]

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -486,3 +486,139 @@ fn test_config_with_nested_serialization() {
     &expected
   );
 }
+
+#[test]
+fn test_scripts_serialization() {
+  let json = r#"
+    {
+        "name": "my-project",
+        "version": "1.0.0",
+        "scripts": {
+            "start": "node index.js",
+            "test": "jest",
+            "build": "webpack --mode production",
+            "lint": "eslint ."
+        }
+    }"#;
+  let package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  assert_eq!(package_json.scripts.get("start").unwrap(), "node index.js");
+  assert_eq!(package_json.scripts.get("test").unwrap(), "jest");
+  assert_eq!(
+    package_json.scripts.get("build").unwrap(),
+    "webpack --mode production"
+  );
+  assert_eq!(package_json.scripts.get("lint").unwrap(), "eslint .");
+}
+
+#[test]
+fn test_dependencies_and_dev_dependencies() {
+  let json = r#"
+    {
+        "name": "my-library",
+        "version": "2.1.0",
+        "dependencies": {
+            "lodash": "^4.17.21",
+            "axios": "^0.21.1"
+        },
+        "devDependencies": {
+            "jest": "^27.0.6",
+            "typescript": "^4.3.5"
+        }
+    }"#;
+  let package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  assert_eq!(
+    package_json
+      .dependencies
+      .as_ref()
+      .unwrap()
+      .get("lodash")
+      .unwrap(),
+    "^4.17.21"
+  );
+  assert_eq!(
+    package_json
+      .dependencies
+      .as_ref()
+      .unwrap()
+      .get("axios")
+      .unwrap(),
+    "^0.21.1"
+  );
+  assert_eq!(
+    package_json
+      .dev_dependencies
+      .as_ref()
+      .unwrap()
+      .get("jest")
+      .unwrap(),
+    "^27.0.6"
+  );
+  assert_eq!(
+    package_json
+      .dev_dependencies
+      .as_ref()
+      .unwrap()
+      .get("typescript")
+      .unwrap(),
+    "^4.3.5"
+  );
+}
+
+#[test]
+fn test_engines_and_os() {
+  let json = r#"
+    {
+        "name": "node-specific-package",
+        "version": "1.2.3",
+        "engines": {
+            "node": ">=14.0.0",
+            "npm": ">=6.0.0"
+        },
+        "os": ["darwin", "linux"]
+    }"#;
+  let package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  assert_eq!(
+    package_json.engines.as_ref().unwrap().get("node").unwrap(),
+    ">=14.0.0"
+  );
+  assert_eq!(
+    package_json.engines.as_ref().unwrap().get("npm").unwrap(),
+    ">=6.0.0"
+  );
+  assert_eq!(
+    package_json.os.as_ref().unwrap(),
+    &vec!["darwin".to_string(), "linux".to_string()]
+  );
+}
+
+#[test]
+fn test_bin_and_man() {
+  let json = r#"
+    {
+        "name": "cli-tool",
+        "version": "3.0.1",
+        "bin": {
+            "my-cli": "./bin/cli.js"
+        },
+        "man": [
+            "./man/doc.1",
+            "./man/doc.2"
+        ]
+    }"#;
+  let package_json = serde_json::from_str::<PackageJson>(json).unwrap();
+  match &package_json.bin {
+    Some(PackageBin::Record(bin_map)) => {
+      assert_eq!(bin_map.get("my-cli").unwrap(), "./bin/cli.js");
+    }
+    _ => panic!("Expected bin to be a Record"),
+  }
+  match &package_json.man {
+    Some(PackageMan::Slice(man_vec)) => {
+      assert_eq!(
+        man_vec,
+        &vec!["./man/doc.1".to_string(), "./man/doc.2".to_string()]
+      );
+    }
+    _ => panic!("Expected man to be a Slice"),
+  }
+}


### PR DESCRIPTION
This change introduces improved support for handling [repository](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository) in a `package.json` file. The implementation before this change didn't support all possible variations.

Previously Supported:

```json
{
  "repository": {
    "type": "git",
    "url": "git+https://github.com/npm/cli.git"
  }
}
```

Introducing Support for:

```json
"repository": "gitlab:user/repo"
```
and

```json
  "repository": {
    "type": "git",
    "url": "git+https://github.com/npm/cli.git",
    "directory": "workspaces/libnpmpublish"
  }
```

I have included tests for these changes. I've tried to keep to existing patterns for consistency. It appears that the handling of enums has changed over time in serde, I've had to go back and update the serde configuration to make all of the enum's "untagged" to parse package.json files with recent versions of rust.