### PR TITLE
feat: add custom error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ all-features = true
 
 [dependencies]
 serde = { version = "1.0.138", features = ["derive"] }
-anyhow = "1.0.58"
 serde_json = "1.0.138"
 derive_builder = "0.20.2"
+thiserror = "2.0.12"
 
 [features]
 default = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use thiserror::Error as ThisError;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(ThisError, Debug)]
+pub enum Error {
+  #[error(transparent)]
+  IO(#[from] std::io::Error),
+  #[error(transparent)]
+  Serde(#[from] serde_json::Error),
+  #[error("Couldn't find an available \"{filename}\" from {}.", .current_dir.display())]
+  NotFound {
+    filename: String,
+    current_dir: PathBuf,
+  },
+  #[error("Couldn't find an available {0} file")]
+  MissingPackageJson(String),
+}
+

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,8 @@
-use anyhow::{format_err, Result};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
 
 use self::write_options::WriteOptions;
 
@@ -15,11 +16,10 @@ pub fn find_closest_file<P: AsRef<Path>>(filename: &str, current_dir: P) -> Resu
       return Ok(file_path);
     }
     if !current_dir.pop() {
-      return Err(format_err!(
-        "Couldn't find an available \"{}\" from {}.",
-        filename,
-        current_dir.display()
-      ));
+      return Err(Error::NotFound {
+        filename: filename.to_string(),
+        current_dir,
+      });
     }
   }
 }
@@ -32,12 +32,8 @@ where
   let mut file = File::open(file_path)?;
   let mut contents = String::new();
   file.read_to_string(&mut contents)?;
-  let serialized_json = serde_json::from_str(&contents);
 
-  match serialized_json {
-    Ok(json) => Ok(json),
-    Err(error) => Err(format_err!(error)),
-  }
+  Ok(serde_json::from_str(&contents)?)
 }
 
 pub fn write_json<Json, FilePath>(
@@ -53,15 +49,11 @@ where
     serde_json::to_string_pretty(&json)
   } else {
     serde_json::to_string(&json)
-  };
+  }?;
 
-  match package_json {
-    Ok(json_content) => {
-      File::create(file_path)?.write_all(json_content.as_bytes())?;
-      Ok(())
-    }
-    Err(error) => Err(format_err!(error)),
-  }
+  File::create(file_path)?.write_all(package_json.as_bytes())?;
+
+  Ok(())
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,9 @@
 //! ## How to locate the closest `package.json` file
 //!
 //! ```no_run
-//! use package_json::PackageJsonManager;
+//! use package_json::{error::Result, PackageJsonManager};
 //! use std::path::Path;
 //!
-//! # use anyhow::Result;
 //! # fn main() -> Result<()> {
 //! let mut manager = PackageJsonManager::new();
 //! // based on the current working directory
@@ -62,6 +61,7 @@
 //! ```
 //!
 
+pub mod error;
 mod fs;
 mod manager;
 mod schema;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,7 +1,7 @@
+use crate::error::{Error, Result};
 use crate::fs;
 use crate::fs::write_options::WriteOptions;
 use crate::PackageJson;
-use anyhow::{format_err, Result};
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -100,12 +100,7 @@ impl PackageJsonManager {
           self.json = json;
         })
       })
-      .unwrap_or_else(|| {
-        Err(format_err!(
-          "Couldn't find an available {} file.",
-          PACKAGE_JSON_FILENAME
-        ))
-      })
+      .unwrap_or_else(|| Err(Error::MissingPackageJson(PACKAGE_JSON_FILENAME.to_string())))
   }
 
   ///
@@ -163,12 +158,7 @@ impl PackageJsonManager {
             .expect("self.write_options should not be None"),
         )
       })
-      .unwrap_or_else(|| {
-        Err(format_err!(
-          "Couldn't find an available {} file.",
-          PACKAGE_JSON_FILENAME
-        ))
-      })
+      .unwrap_or_else(|| Err(Error::MissingPackageJson(PACKAGE_JSON_FILENAME.to_string())))
   }
 
   /// Write the current `package.json` content to the specific `package.json` file.


### PR DESCRIPTION
This PR drops `anyhow` in favor of an error type that implements the `std::error::Error` trait. So any trait object based error handling type can be used (i.e. `eyre`, `anyhow`, etc). 